### PR TITLE
Update ffjavascript

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/iden3/circom_runtime#readme",
   "dependencies": {
-    "ffjavascript": "0.2.10",
+    "ffjavascript": "0.2.33",
     "fnv-plus": "^1.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Snarkjs uses this dependency, so to fix the build step in snarkjs, we also need to update ffjavascript here.