### PR TITLE
Add funtion to transform a witness from the JSON format to the binary format

### DIFF
--- a/build/main.cjs
+++ b/build/main.cjs
@@ -574,6 +574,75 @@ class WitnessCalculatorCircom2 {
         return buff;
     }
 
+    async fromJSONtoWTNSBin(input, sanityCheck) {
+        this.instance.exports.init((this.sanityCheck || sanityCheck) ? 1 : 0);
+        const buff32 = new Uint32Array(this.witnessSize * this.n32 + this.n32 + 11);
+        const buff = new Uint8Array(buff32.buffer);
+
+        //"wtns"
+        buff[0] = "w".charCodeAt(0);
+        buff[1] = "t".charCodeAt(0);
+        buff[2] = "n".charCodeAt(0);
+        buff[3] = "s".charCodeAt(0);
+
+        //version 2
+        buff32[1] = 2;
+
+        //number of sections: 2
+        buff32[2] = 2;
+
+        //id section 1
+        buff32[3] = 1;
+
+        const n8 = this.n32 * 4;
+        //id section 1 length in 64bytes
+        const idSection1length = 8 + n8;
+        const idSection1lengthHex = idSection1length.toString(16);
+        buff32[4] = parseInt(idSection1lengthHex.slice(0, 8), 16);
+        buff32[5] = parseInt(idSection1lengthHex.slice(8, 16), 16);
+
+        //this.n32
+        buff32[6] = n8;
+
+        //prime number
+        this.instance.exports.getRawPrime();
+
+        var pos = 7;
+        for (let j = 0; j < this.n32; j++) {
+            buff32[pos + j] = this.instance.exports.readSharedRWMemory(j);
+        }
+        pos += this.n32;
+
+        // witness size
+        buff32[pos] = this.witnessSize;
+        pos++;
+
+        //id section 2
+        buff32[pos] = 2;
+        pos++;
+
+        // section 2 length
+        const idSection2length = n8 * this.witnessSize;
+        const idSection2lengthHex = idSection2length.toString(16);
+        buff32[pos] = parseInt(idSection2lengthHex.slice(0, 8), 16);
+        buff32[pos + 1] = parseInt(idSection2lengthHex.slice(8, 16), 16);
+
+        pos += 2;
+        for (let v of input) {
+            let arrayValue = ffjavascript.Scalar.toArray(v, 0x100000000).reverse();
+            for (let i = arrayValue.length; i < 8; i++) {
+                arrayValue.push(0);
+            }
+            const finalArray = new Uint32Array(arrayValue);
+            for (let j = 0; j < this.n32; j++) {
+                buff32[pos + j] = finalArray[j];
+            }
+            pos += this.n32;
+        }
+
+        return buff;
+    }
+
 }
 
 exports.WitnessCalculatorBuilder = builder;

--- a/calcwit.js
+++ b/calcwit.js
@@ -24,12 +24,13 @@ const version = pkg.version;
 import WitnessCalculatorBuilder from "./js/witness_calculator.js";
 import { utils } from "ffjavascript";
 import yargs from "yargs";
+import { hideBin } from 'yargs/helpers'
 
 
 
-const argv = yargs
+const argv = yargs(hideBin(process.argv))
     .version(version)
-    .usage("calcwit -w [wasm file] -i [input file JSON] -o [output ouput file file  .json|.bin]")
+    .usage("calcwit -w [wasm file] -i [input file JSON] -o [output file  .json|.bin]")
     .alias("o", "output")
     .alias("i", "input")
     .alias("w", "wasm")

--- a/conwit.js
+++ b/conwit.js
@@ -18,8 +18,14 @@ limitations under the License.
 */
 
 import fs from "fs";
-const pkg = JSON.parse(fs.readFileSync("./package.json"));
+import path from "path";
+import {fileURLToPath} from 'url';
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const pkg = JSON.parse(fs.readFileSync(__dirname + "/package.json"));
 const version = pkg.version;
+
 
 import WitnessCalculatorBuilder from "./js/witness_calculator.js";
 import { utils } from "ffjavascript";

--- a/conwit.js
+++ b/conwit.js
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+/*
+
+Copyright 2022 0KIMS association.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+import fs from "fs";
+const pkg = JSON.parse(fs.readFileSync("./package.json"));
+const version = pkg.version;
+
+import WitnessCalculatorBuilder from "./js/witness_calculator.js";
+import { utils } from "ffjavascript";
+import yargs from "yargs";
+import { hideBin } from 'yargs/helpers'
+
+
+
+const argv = yargs(hideBin(process.argv))
+    .version(version)
+    .usage("calcwit -w [wasm file] -i [input file JSON] -o [output file .bin]")
+    .alias("o", "output")
+    .alias("i", "input")
+    .alias("w", "wasm")
+    .help("h")
+    .alias("h", "help")
+    .epilogue(`Copyright (C) 2018  0kims association
+    This program comes with ABSOLUTELY NO WARRANTY;
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; see the COPYING file in the official
+    repo directory at  https://github.com/iden3/circom `)
+    .argv;
+
+const inputFileName = typeof(argv.input) === "string" ?  argv.input : "wtns.json";
+const outputFileName = typeof(argv.output) === "string" ?  argv.output : "witness.bin";
+const wasmFileName = typeof(argv.wasm) === "string" ?  argv.wasm : "circuit.wasm";
+
+
+async function run() {
+
+
+    const input = utils.unstringifyBigInts(JSON.parse(await fs.promises.readFile(inputFileName, "utf8")));
+    const wasm = await fs.promises.readFile(wasmFileName);
+
+    const wc = await WitnessCalculatorBuilder(wasm);
+
+    const w = await wc.fromJSONtoWTNSBin(input);
+
+    var wstream = fs.createWriteStream(outputFileName);
+
+    wstream.write(Buffer.from(w));
+    wstream.end();
+    await new Promise(fulfill => wstream.on("finish", fulfill));
+}
+
+
+run();

--- a/js/witness_calculator.js
+++ b/js/witness_calculator.js
@@ -522,4 +522,73 @@ class WitnessCalculatorCircom2 {
         return buff;
     }
 
+    async fromJSONtoWTNSBin(input, sanityCheck) {
+        this.instance.exports.init((this.sanityCheck || sanityCheck) ? 1 : 0);
+        const buff32 = new Uint32Array(this.witnessSize * this.n32 + this.n32 + 11);
+        const buff = new Uint8Array(buff32.buffer);
+
+        //"wtns"
+        buff[0] = "w".charCodeAt(0);
+        buff[1] = "t".charCodeAt(0);
+        buff[2] = "n".charCodeAt(0);
+        buff[3] = "s".charCodeAt(0);
+
+        //version 2
+        buff32[1] = 2;
+
+        //number of sections: 2
+        buff32[2] = 2;
+
+        //id section 1
+        buff32[3] = 1;
+
+        const n8 = this.n32 * 4;
+        //id section 1 length in 64bytes
+        const idSection1length = 8 + n8;
+        const idSection1lengthHex = idSection1length.toString(16);
+        buff32[4] = parseInt(idSection1lengthHex.slice(0, 8), 16);
+        buff32[5] = parseInt(idSection1lengthHex.slice(8, 16), 16);
+
+        //this.n32
+        buff32[6] = n8;
+
+        //prime number
+        this.instance.exports.getRawPrime();
+
+        var pos = 7;
+        for (let j = 0; j < this.n32; j++) {
+            buff32[pos + j] = this.instance.exports.readSharedRWMemory(j);
+        }
+        pos += this.n32;
+
+        // witness size
+        buff32[pos] = this.witnessSize;
+        pos++;
+
+        //id section 2
+        buff32[pos] = 2;
+        pos++;
+
+        // section 2 length
+        const idSection2length = n8 * this.witnessSize;
+        const idSection2lengthHex = idSection2length.toString(16);
+        buff32[pos] = parseInt(idSection2lengthHex.slice(0, 8), 16);
+        buff32[pos + 1] = parseInt(idSection2lengthHex.slice(8, 16), 16);
+
+        pos += 2;
+        for (let v of input) {
+            let arrayValue = Scalar.toArray(v, 0x100000000).reverse();
+            for (let i = arrayValue.length; i < 8; i++) {
+                arrayValue.push(0);
+            }
+            const finalArray = new Uint32Array(arrayValue);
+            for (let j = 0; j < this.n32; j++) {
+                buff32[pos + j] = finalArray[j];
+            }
+            pos += this.n32;
+        }
+
+        return buff;
+    }
+
 }


### PR DESCRIPTION
This PR does the following changes:

* Implements `fromJSONtoWTNSBin` to transform a witness from the JSON format to the binary one. This could be useful for debugging and testing purposes.
* Adds `conwit.js` script that calls `fromJSONtoWTNSBin`.
* Fixes an error related to [yargs](https://github.com/yargs/yargs/issues/1854) on `calcwit.js`.

Example run.

```
➜ ls example
circuit.wasm witness.json
➜ ./conwit.js -w example/circuit.wasm -i example/witness.json -o example/witness.bin
➜ snarkjs wej example/witness.bin example/witness2.json
➜ diff example/witness2.json example/witness.json
```