### PR TITLE
fix negative input bug

### DIFF
--- a/build/main.cjs
+++ b/build/main.cjs
@@ -473,7 +473,11 @@ class WitnessCalculatorCircom2 {
             const hLSB = parseInt(h.slice(8,16), 16);
             const fArr = flatArray(input[k]);
             for (let i=0; i<fArr.length; i++) {
-        const arrFr = toArray32(fArr[i],this.n32);
+        let possibleNegative = BigInt(fArr[i]);
+        while (possibleNegative < 0n) {
+            possibleNegative += this.prime;
+        }
+        const arrFr = toArray32(possibleNegative % this.prime, this.n32);
         for (let j=0; j<this.n32; j++) {
             this.instance.exports.writeSharedRWMemory(j,arrFr[this.n32-1-j]);
         }

--- a/js/witness_calculator.js
+++ b/js/witness_calculator.js
@@ -421,7 +421,11 @@ class WitnessCalculatorCircom2 {
             const hLSB = parseInt(h.slice(8,16), 16);
             const fArr = flatArray(input[k]);
             for (let i=0; i<fArr.length; i++) {
-        const arrFr = toArray32(fArr[i],this.n32)
+        let possibleNegative = BigInt(fArr[i])
+        while (possibleNegative < 0n) {
+            possibleNegative += this.prime
+        }
+        const arrFr = toArray32(possibleNegative % this.prime, this.n32)
         for (let j=0; j<this.n32; j++) {
             this.instance.exports.writeSharedRWMemory(j,arrFr[this.n32-1-j]);
         }


### PR DESCRIPTION
Same bug as fixed in https://github.com/0xPARC/zkrepl/pull/13/ and effecting use of https://github.com/projectsophon/hardhat-circom. I originally thought it would be fixed by updating the version of circom being used in hardhat as per https://github.com/projectsophon/hardhat-circom/pull/80 but realize the problem is with this library.