### PR TITLE
fix: Use Uint32Array when calculating prime as is done in circom2

### DIFF
--- a/build/main.cjs
+++ b/build/main.cjs
@@ -447,7 +447,7 @@ class WitnessCalculatorCircom2 {
         this.n32 = this.instance.exports.getFieldNumLen32();
 
         this.instance.exports.getRawPrime();
-        const arr = new Array(this.n32);
+        const arr = new Uint32Array(this.n32);
         for (let i=0; i<this.n32; i++) {
             arr[this.n32-1-i] = this.instance.exports.readSharedRWMemory(i);
         }

--- a/js/witness_calculator.js
+++ b/js/witness_calculator.js
@@ -395,7 +395,7 @@ class WitnessCalculatorCircom2 {
         this.n32 = this.instance.exports.getFieldNumLen32();
 
         this.instance.exports.getRawPrime();
-        const arr = new Array(this.n32);
+        const arr = new Uint32Array(this.n32);
         for (let i=0; i<this.n32; i++) {
             arr[this.n32-1-i] = this.instance.exports.readSharedRWMemory(i);
         }


### PR DESCRIPTION
`p` was incorrectly being calculated as `21888242844879328548818664213742077600362041385367538672338993241347936223233n` instead of `21888242871839275222246405745257275088548364400416034343698204186575808495617n` as referenced in #87. This PR corrects the miscalculation by using an unsigned 32 byte array instead of a standard array.