### PR TITLE
Allow for passing/reusing existing WASM instance

### DIFF
--- a/build/main.cjs
+++ b/build/main.cjs
@@ -101,8 +101,6 @@ async function createWASMInstance(wasmSource, options) {
 
     const wasmModule = await WebAssembly.compile(wasmSource);
 
-    let wc;
-
     let errStr = "";
     let msgStr = "";
 
@@ -206,6 +204,8 @@ async function createWASMInstance(wasmSource, options) {
 
     WebAssembly.instantiate(wasmModule, importsObject);
 
+    return wasmModule;
+
     function getMessage() {
         var message = "";
         var c = instance.exports.getMessageChar();
@@ -260,6 +260,8 @@ async function builder(codeOrWasmInstance, options) {
             options.logStartComponent ||
             options.logFinishComponent
         );
+
+    let wc;
 
     // We explicitly check for major version 2 in case there's a circom v3 in the future
     if (majorVersion === 2) {

--- a/build/main.cjs
+++ b/build/main.cjs
@@ -80,165 +80,150 @@ function toArray32(s,size) {
 
 /* globals WebAssembly */
 
-
-async function createWASMInstance(wasmSource, options) {
-
-    let memorySize = 32767;
-    let memory;
-    let memoryAllocated = false;
-    while (!memoryAllocated){
-        try{
-            memory = new WebAssembly.Memory({initial:memorySize});
-            memoryAllocated = true;
-        } catch(err){
-            if(memorySize === 1){
-                throw err;
-            }
-            console.warn("Could not allocate " + memorySize * 1024 * 64 + " bytes. This may cause severe instability. Trying with " + memorySize * 1024 * 64 / 2 + " bytes");
-            memorySize = Math.floor(memorySize/2);
-        }
-    }
-
-    const wasmModule = await WebAssembly.compile(wasmSource);
-
-    let errStr = "";
-    let msgStr = "";
-
-    let importsObject = {
-        env: {
-            "memory": memory
-        },
-        runtime: {
-            exceptionHandler: function(code) {
-                let err;
-                if (code == 1) {
-                    err = "Signal not found. ";
-                } else if (code == 2) {
-                    err = "Too many signals set. ";
-                } else if (code == 3) {
-                    err = "Signal already set. ";
-                } else if (code == 4) {
-                    err = "Assert Failed. ";
-                } else if (code == 5) {
-                    err = "Not enough memory. ";
-                } else if (code == 6) {
-                    err = "Input signal array access exceeds the size. ";
-                } else {
-                    err = "Unknown error. ";
-                }
-                console.error("ERROR: ", code, errStr);
-                throw new Error(err + errStr);
-            },
-            // A new way of logging messages was added in Circom 2.0.7 that requires 2 new imports
-            // `printErrorMessage` and `writeBufferMessage`.
-            printErrorMessage: function() {
-                errStr += getMessage() + "\n";
-            },
-            writeBufferMessage: function() {
-                const msg = getMessage();
-                // Any calls to `log()` will always end with a `\n`, so that's when we print and reset
-                if (msg === "\n") {
-                    console.log(msgStr);
-                    msgStr = "";
-                } else {
-                    // If we've buffered other content, put a space in between the items
-                    if (msgStr !== "") {
-                        msgStr += " ";
-                    }
-                    // Then append the message to the message we are creating
-                    msgStr += msg;
-                }
-            },
-            showSharedRWMemory: function() {
-                const shared_rw_memory_size = instance.exports.getFieldNumLen32();
-                const arr = new Uint32Array(shared_rw_memory_size);
-                for (let j=0; j<shared_rw_memory_size; j++) {
-                    arr[shared_rw_memory_size-1-j] = instance.exports.readSharedRWMemory(j);
-                }
-
-                // In circom 2.0.7, they changed the log() function to allow strings and changed the
-                // output API. This smoothes over the breaking change.
-                {
-                    console.log(ffjavascript.Scalar.fromArray(arr, 0x100000000));
-                }
-            },
-            error: function(code, pstr, a,b,c,d) {
-                let errStr;
-                if (code == 7) {
-                    errStr=p2str(pstr) + " " + wc.getFr(b).toString() + " != " + wc.getFr(c).toString() + " " +p2str(d);
-                } else if (code == 9) {
-                    errStr=p2str(pstr) + " " + wc.getFr(b).toString() + " " +p2str(c);
-                } else if ((code == 5)&&(options.sym)) {
-                    errStr=p2str(pstr)+ " " + options.sym.labelIdx2Name[c];
-                } else {
-                    errStr=p2str(pstr)+ " " + a + " " + b + " " + c + " " + d;
-                }
-                console.log("ERROR: ", code, errStr);
-                throw new Error(errStr);
-            },
-            log: function(a) {
-                console.log(wc.getFr(a).toString());
-            },
-            logGetSignal: function(signal, pVal) {
-                if (options.logGetSignal) {
-                    options.logGetSignal(signal, wc.getFr(pVal) );
-                }
-            },
-            logSetSignal: function(signal, pVal) {
-                if (options.logSetSignal) {
-                    options.logSetSignal(signal, wc.getFr(pVal) );
-                }
-            },
-            logStartComponent: function(cIdx) {
-                if (options.logStartComponent) {
-                    options.logStartComponent(cIdx);
-                }
-            },
-            logFinishComponent: function(cIdx) {
-                if (options.logFinishComponent) {
-                    options.logFinishComponent(cIdx);
-                }
-            }
-        }
-    };
-
-    WebAssembly.instantiate(wasmModule, importsObject);
-
-    return wasmModule;
-
-    function getMessage() {
-        var message = "";
-        var c = instance.exports.getMessageChar();
-        while ( c != 0 ) {
-            message += String.fromCharCode(c);
-            c = instance.exports.getMessageChar();
-        }
-        return message;
-    }
-
-    function p2str(p) {
-        const i8 = new Uint8Array(memory.buffer);
-
-        const bytes = [];
-
-        for (let i=0; i8[p+i]>0; i++)  bytes.push(i8[p+i]);
-
-        return String.fromCharCode.apply(null, bytes);
-    }
-
-}
-async function builder(codeOrWasmInstance, options) {
-
-    options = options || {};
-
+async function builder(code, options) {
     let instance;
+    let wc;
 
-    // In the event that you are running witness generation multiple times, it's
-    // better to reuse an existing wasm instance.
-    if (codeOrWasmInstance instanceof WebAssembly.Instance) {
-        instance = codeOrWasmInstance;
+    // Only circom 2 implements version lookup through exports in the WASM
+    // We default to `1` and update if we see the `getVersion` export (major version)
+    // These are updated after the instance is instantiated, assuming the functions are available
+    let majorVersion = 1;
+    // After Circom 2.0.7, Blaine added exported functions for getting minor and patch versions
+    let minorVersion = 0;
+    // If we can't lookup the patch version, assume the lowest
+    let patchVersion = 0;
+
+    if (code instanceof WebAssembly.Instance) {
+        instance = code;
     } else {
-        instance = await createWASMInstance(codeOrWasm, options);
+        options = options || {};
+
+        let memorySize = 32767;
+        let memory;
+        let memoryAllocated = false;
+        while (!memoryAllocated){
+            try{
+                memory = new WebAssembly.Memory({initial:memorySize});
+                memoryAllocated = true;
+            } catch(err){
+                if(memorySize === 1){
+                    throw err;
+                }
+                console.warn("Could not allocate " + memorySize * 1024 * 64 + " bytes. This may cause severe instability. Trying with " + memorySize * 1024 * 64 / 2 + " bytes");
+                memorySize = Math.floor(memorySize/2);
+            }
+        }
+
+        const wasmModule = await WebAssembly.compile(code);
+
+        let errStr = "";
+        let msgStr = "";
+
+        instance = await WebAssembly.instantiate(wasmModule, {
+            env: {
+                "memory": memory
+            },
+            runtime: {
+                exceptionHandler: function(code) {
+                    let err;
+                    if (code == 1) {
+                        err = "Signal not found. ";
+                    } else if (code == 2) {
+                        err = "Too many signals set. ";
+                    } else if (code == 3) {
+                        err = "Signal already set. ";
+                    } else if (code == 4) {
+                        err = "Assert Failed. ";
+                    } else if (code == 5) {
+                        err = "Not enough memory. ";
+                    } else if (code == 6) {
+                        err = "Input signal array access exceeds the size. ";
+                    } else {
+                        err = "Unknown error. ";
+                    }
+                    console.error("ERROR: ", code, errStr);
+                    throw new Error(err + errStr);
+                },
+                // A new way of logging messages was added in Circom 2.0.7 that requires 2 new imports
+                // `printErrorMessage` and `writeBufferMessage`.
+                printErrorMessage: function() {
+                    errStr += getMessage() + "\n";
+                },
+                writeBufferMessage: function() {
+                    const msg = getMessage();
+                    // Any calls to `log()` will always end with a `\n`, so that's when we print and reset
+                    if (msg === "\n") {
+                        console.log(msgStr);
+                        msgStr = "";
+                    } else {
+                        // If we've buffered other content, put a space in between the items
+                        if (msgStr !== "") {
+                            msgStr += " ";
+                        }
+                        // Then append the message to the message we are creating
+                        msgStr += msg;
+                    }
+                },
+                showSharedRWMemory: function() {
+                    const shared_rw_memory_size = instance.exports.getFieldNumLen32();
+                    const arr = new Uint32Array(shared_rw_memory_size);
+                    for (let j=0; j<shared_rw_memory_size; j++) {
+                        arr[shared_rw_memory_size-1-j] = instance.exports.readSharedRWMemory(j);
+                    }
+
+                    // In circom 2.0.7, they changed the log() function to allow strings and changed the
+                    // output API. This smoothes over the breaking change.
+                    if (majorVersion >= 2 && (minorVersion >= 1 || patchVersion >= 7)) {
+                        // If we've buffered other content, put a space in between the items
+                        if (msgStr !== "") {
+                            msgStr += " ";
+                        }
+                        // Then append the value to the message we are creating
+                        const msg = (ffjavascript.Scalar.fromArray(arr, 0x100000000).toString());
+                        msgStr += msg;
+                    } else {
+                        console.log(ffjavascript.Scalar.fromArray(arr, 0x100000000));
+                    }
+                },
+                error: function(code, pstr, a,b,c,d) {
+                    let errStr;
+                    if (code == 7) {
+                        errStr=p2str(pstr) + " " + wc.getFr(b).toString() + " != " + wc.getFr(c).toString() + " " +p2str(d);
+                    } else if (code == 9) {
+                        errStr=p2str(pstr) + " " + wc.getFr(b).toString() + " " +p2str(c);
+                    } else if ((code == 5)&&(options.sym)) {
+                        errStr=p2str(pstr)+ " " + options.sym.labelIdx2Name[c];
+                    } else {
+                        errStr=p2str(pstr)+ " " + a + " " + b + " " + c + " " + d;
+                    }
+                    console.log("ERROR: ", code, errStr);
+                    throw new Error(errStr);
+                },
+                log: function(a) {
+                    console.log(wc.getFr(a).toString());
+                },
+                logGetSignal: function(signal, pVal) {
+                    if (options.logGetSignal) {
+                        options.logGetSignal(signal, wc.getFr(pVal) );
+                    }
+                },
+                logSetSignal: function(signal, pVal) {
+                    if (options.logSetSignal) {
+                        options.logSetSignal(signal, wc.getFr(pVal) );
+                    }
+                },
+                logStartComponent: function(cIdx) {
+                    if (options.logStartComponent) {
+                        options.logStartComponent(cIdx);
+                    }
+                },
+                logFinishComponent: function(cIdx) {
+                    if (options.logFinishComponent) {
+                        options.logFinishComponent(cIdx);
+                    }
+                }
+            }
+        });
     }
 
     if (typeof instance.exports.getVersion == 'function') {
@@ -261,8 +246,6 @@ async function builder(codeOrWasmInstance, options) {
             options.logFinishComponent
         );
 
-    let wc;
-
     // We explicitly check for major version 2 in case there's a circom v3 in the future
     if (majorVersion === 2) {
         wc = new WitnessCalculatorCircom2(instance, sanityCheck);
@@ -272,6 +255,25 @@ async function builder(codeOrWasmInstance, options) {
     }
     return wc;
 
+    function getMessage() {
+        var message = "";
+        var c = instance.exports.getMessageChar();
+        while ( c != 0 ) {
+            message += String.fromCharCode(c);
+            c = instance.exports.getMessageChar();
+        }
+        return message;
+    }
+
+    function p2str(p) {
+        const i8 = new Uint8Array(memory.buffer);
+
+        const bytes = [];
+
+        for (let i=0; i8[p+i]>0; i++)  bytes.push(i8[p+i]);
+
+        return String.fromCharCode.apply(null, bytes);
+    }
 }
 class WitnessCalculatorCircom1 {
     constructor(memory, instance, sanityCheck) {

--- a/js/witness_calculator.js
+++ b/js/witness_calculator.js
@@ -56,7 +56,7 @@ export default async function builder(code, options) {
     // If we can't lookup the patch version, assume the lowest
     let patchVersion = 0;
 
-    const instance = await WebAssembly.instantiate(wasmModule, {
+    let importsObject = {
         env: {
             "memory": memory
         },
@@ -160,7 +160,9 @@ export default async function builder(code, options) {
                 }
             }
         }
-    });
+    };
+
+    const instance = await WebAssembly.instantiate(wasmModule, { ...importsObject, ...options.additionalWASMImports });
 
     if (typeof instance.exports.getVersion == 'function') {
         majorVersion = instance.exports.getVersion();

--- a/js/witness_calculator.js
+++ b/js/witness_calculator.js
@@ -41,8 +41,6 @@ export async function createWASMInstance(wasmSource, options) {
 
     const wasmModule = await WebAssembly.compile(wasmSource);
 
-    let wc;
-
     let errStr = "";
     let msgStr = "";
 
@@ -163,6 +161,8 @@ export async function createWASMInstance(wasmSource, options) {
 
     WebAssembly.instantiate(wasmModule, importsObject);
 
+    return wasmModule;
+
     function getMessage() {
         var message = "";
         var c = instance.exports.getMessageChar();
@@ -218,6 +218,8 @@ export default async function builder(codeOrWasmInstance, options) {
             options.logStartComponent ||
             options.logFinishComponent
         );
+
+    let wc;
 
     // We explicitly check for major version 2 in case there's a circom v3 in the future
     if (majorVersion === 2) {

--- a/js/witness_calculator.js
+++ b/js/witness_calculator.js
@@ -164,6 +164,10 @@ export default async function builder(code, options) {
 
     const instance = await WebAssembly.instantiate(wasmModule, { ...importsObject, ...options.additionalWASMImports });
 
+    if (options.initializeWasiReactorModuleInstance) {
+        options.initializeWasiReactorModuleInstance(instance);
+    }
+
     if (typeof instance.exports.getVersion == 'function') {
         majorVersion = instance.exports.getVersion();
     }


### PR DESCRIPTION
NOTE: This PR looks worse than it is -- the diff misrepresents the changes. 

### Changes

- factor out `createWASMInstance` function to build the WASM instance from source code
- change `witness_calculator.builder` to check if being passed wasm binary or existing wasm instance

The changes are non-breaking. In fact the code path is exactly the same if you pass in WASM source code to the constructor.

### Other Context
I'm working on a project which produces a WASM binary that is compatible with the circom witness calculating binary. The standards for serializing witness files, r1cs, keys etc was documented, and it was easy enough to reverse engineer the necessary API for the witness solver. 

However, my WASM binary is compiled via Haskell's GHC WASM backend which requires the `wasi_snapshot_preview_1` apis to be included in the instance. This PR allows me to do that with minimal (non-breaking) changes. Here is an example project which does this: 

https://github.com/l-adic/factors/blob/main/app/Prover/Prove.js#L62