### PR TITLE
fix: change initial memory size parameter from 32767 to 0 in `witness_calculator`

### DIFF
--- a/build/main.cjs
+++ b/build/main.cjs
@@ -84,7 +84,7 @@ async function builder(code, options) {
 
     options = options || {};
 
-    let memorySize = 32767;
+    let memorySize = 0;
     let memory;
     let memoryAllocated = false;
     while (!memoryAllocated){

--- a/js/witness_calculator.js
+++ b/js/witness_calculator.js
@@ -24,7 +24,7 @@ export default async function builder(code, options) {
 
     options = options || {};
 
-    let memorySize = 32767;
+    let memorySize = 0;
     let memory;
     let memoryAllocated = false;
     while (!memoryAllocated){


### PR DESCRIPTION
The current behavior of the witness calculator builder code is that when initializing a witness calculator wasm module, it specifies an initial memory size equal to `32767 * 64kb ~= 2gb` (the `initial` argument is interpreted as 'quantity of pages', and each 'page' in wasm is specified to be `64kb`). If allocating that quantity of memory fails, the code performs an exponential backoff with a factor of `2` - i.e. it then attempts to allocate `1gb`, then `512mb`, then `256mb`, until allocation succeeds or fails at `0` pages.

This memory allocation strategy poses a problem for us at [zupass](https://github.com/proofcarryingdata/zupass). Our app is built primarily for phones, where memory is much more limited than on desktop environments. Thus, in practice, we have found that our website crashes with an OOM after ~2 proofs on older devices, which results in a poor user experience for a non-negligible portion of our users.

After identifying the section of code modified in this PR as being the culprit behind the OOM crashes, I forked and modified the `circom_runtime` and `snarkjs` libraries with the same change that I am proposing in this pull request. These forks are now included in the zupass repo [here](https://github.com/proofcarryingdata/zupass/tree/main/packages/patched). I verified that this change worked properly by making sure that my forked `snarkjs` depended on my forked `circom_runtime`, and that the tests defined in my forked `snarkjs` package indeed passed.

<details>
<summary>logs from running `yarn test` in <a href="https://github.com/proofcarryingdata/zupass/tree/main/packages/patched/snarkjs">my fork of snarkjs</a></summary>

```
➜  snarkjs git:(main) yarn test
yarn run v1.22.21
$ mocha


  Fflonk test suite
    ✔ fflonk full prove (319ms)

  Full process
    ✔ powersoftau new (43ms)
    ✔ powersoftau contribute  (1050ms)
    ✔ powersoftau export challenge
    ✔ powersoftau challenge contribute (1034ms)
    ✔ powersoftau import response (245ms)
    ✔ powersoftau beacon (1095ms)
    ✔ powersoftau prepare phase2 (15149ms)
    ✔ powersoftau verify (890ms)
    ✔ groth16 setup (973ms)
    ✔ zkey contribute  (153ms)
    ✔ zkey export bellman (456ms)
    ✔ zkey bellman contribute (145ms)
    ✔ zkey import bellman (567ms)
    ✔ zkey beacon (144ms)
    ✔ zkey verify r1cs (1067ms)
    ✔ zkey verify init (99ms)
    ✔ zkey export verificationkey
allocating 5
    ✔ witness calculate
    ✔ checks witness complies with r1cs
    ✔ groth16 proof (115ms)
    ✔ groth16 verify
    ✔ plonk setup (220ms)
    ✔ zkey export verificationkey
    ✔ plonk proof (904ms)
    ✔ plonk verify

  keypair
    ✔ It should calculate the right g2_s for the test vectors (38ms)

  snarkjs: Polynomial tests
    ✔ should return the correct degree
    ✔ should check if two polynomials are equal
    ✔ it should blind coefficients
    ✔ should get the correct coefficient
    ✔ should get the correct length
    ✔ should evaluate a polynomial
    ✔ should add a polynomial
    ✔ should sub a polynomial
    ✔ should mul a polynomial with a scalar
    ✔ should add a scalar
    ✔ should sub a scalar
    ✔ should divide by a polynomial
    ✔ should divide by (X^m - y)
    ✔ should multiply by (X-value)
    ✔ should multiply by X
    ✔ should exp a polynomial
    ✔ should split a polynomial
    ✔ should truncate a polynomial
    ✔ should interpolate a polynomial using Lagrange Interpolation
    ✔ should compute a zerofier polynomial


  47 passing (26s)

✨  Done in 26.48s.
```

</details>

Another change I performed on the `zupass` end is that I used the npm `patch-package` package to manually patch these two lines of code during package installation of our dependencies. You can see how I did that [here](https://github.com/proofcarryingdata/zupass/pull/1797). I tested that proving and verifying our zk proofs worked properly by running the proving and verification code via some UI interactions that zupass supports.

It is my understanding that memory can be allocated dynamically by the wasm runtime. From perusing this package, it seems that the wasm builder code is a c++ program, which uses `malloc`, which I understand to be possible in wasm due to the existence of the `memory.grow` instruction. From my current perspective, it seems that specifying an initial memory size is not strictly necessary for the proper functioning of a wasm module. Perhaps this implementation was designed to be the way that it is to increase the performance of a single-proof use-case? I could see it being possible that the current behavior results in faster proving due to not having to allocate wasm memory multiple times.

Anyways, I do not have a full understanding of how the code I am proposing to modify ended up in the state that it is now, and would appreciate some guidance/explanation if possible. Additionally, perhaps there are some technical limitations to changing the initial memory size to be `0` that I am not aware of due to a lack of context.

To conclude: I believe this proposed change to be a strict improvement over the current implementation (holding some space for uncertainty), as it enables a larger quantity of proofs to be generated in memory-constrained environments, which are the environments we are targeting with zupass.

Please let me know if there is any other information needed to get this merged, or how we might arrive to more certainty regarding the correctness of this change.
